### PR TITLE
fix: use us-2 as default region

### DIFF
--- a/falcon-container-sensor-pull.sh
+++ b/falcon-container-sensor-pull.sh
@@ -4,9 +4,9 @@ File: falcon-container-sensor-pull.sh
 Description: Bash script to pull Falcon DaemonSet & Container Sensor images from CrowdStrike Container Registry.
 #DESCRIPTION#
 
-usage() 
+usage()
 {
-    echo "usage: 
+    echo "usage:
 $0 \\
     -f | --cid <FALCONCID> \\
     -u | --clientid <FALCONCLIENTID> \\
@@ -89,7 +89,7 @@ if [[ $GOV = true ]]; then
     REGISTRY="registry.laggar.gcw"
 elif [[ -z "${CS_REGION}" ]]; then
     echo "\$CS_REGION variable not set, assuming US-1"
-    REGION="us-1"
+    REGION="us-2"
     API="api"
     REGISTRY="registry"
 else
@@ -126,7 +126,7 @@ fi
 #Get BEARER token for Registry
 REGISTRYBEARER=$(curl -X GET -s -u "fc-${CIDLOWER}:${ART_PASSWORD}" "https://$REGISTRY.crowdstrike.com/v2/token?=fc-${CIDLOWER}&scope=repository:$SENSORTYPE/$REGION/release/falcon-sensor:pull&service=registry.crowdstrike.com" | jq -r '.token')
 #Get latest sensor version
-LATESTSENSOR=$(curl -X GET -s -H "authorization: Bearer ${REGISTRYBEARER}" "https://$REGISTRY.crowdstrike.com/v2/$SENSORTYPE/$REGION/release/falcon-sensor/tags/list" | jq -r '.tags[-1]') 
+LATESTSENSOR=$(curl -X GET -s -H "authorization: Bearer ${REGISTRYBEARER}" "https://$REGISTRY.crowdstrike.com/v2/$SENSORTYPE/$REGION/release/falcon-sensor/tags/list" | jq -r '.tags[-1]')
 #Construct full image path
 FULLIMAGEPATH="$REGISTRY.crowdstrike.com/$SENSORTYPE/${REGION}/release/falcon-sensor:${LATESTSENSOR}"
 #Pull the container image locally


### PR DESCRIPTION
👋  Thanks for the script!

It appears either the `us-1` region is offline or has been taken down:

```
❯ dig api.us-1.crowdstrike.com @1.1.1.1

; <<>> DiG 9.10.6 <<>> api.us-1.crowdstrike.com @1.1.1.1
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 20287
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;api.us-1.crowdstrike.com.	IN	A

;; AUTHORITY SECTION:
us-1.crowdstrike.com.	900	IN	SOA	ns-1426.awsdns-50.org. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400

;; Query time: 45 msec
;; SERVER: 1.1.1.1#53(1.1.1.1)
;; WHEN: Tue Aug 09 17:10:10 MST 2022
;; MSG SIZE  rcvd: 135
```

And `api.crowdstrike.com` tries to redirect to `us-2` by default:

```
curl -v --data "client_id=${CS_CLIENT_ID}&client_secret=${CS_CLIENT_SECRET}" --request POST https://api.crowdstrike.com/oauth2/token

...
...
* Mark bundle as not supporting multiuse
< HTTP/1.1 308 Permanent Redirect
< Server: nginx
< Date: Wed, 10 Aug 2022 00:12:01 GMT
< Content-Length: 0
< Connection: keep-alive
< Location: https://api.us-2.crowdstrike.com/oauth2/token
< X-Cs-Region: us-2
< X-Cs-Traceid: 29e7fa13-490e-4a3f-8e43-10adae32bc28
< X-Ratelimit-Limit: 300
< X-Ratelimit-Remaining: 298
< Strict-Transport-Security: max-age=31536000; includeSubDomains
<
* Connection #0 to host api.crowdstrike.com left intact
```

This PR updates the default region to `us-2`.